### PR TITLE
feat: Add GET support, deprecate `requestData`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Install using npm:
 ```npm i @gemeentenijmegen/apiclient```
 
 The client expects either the following environment parameters to be set, or to be provided a client certificate, private key and root ca:
-```
 
 ```
   MTLS_PRIVATE_KEY_ARN // AWS Arn to the secrets manager ARN holding the private key
@@ -18,11 +17,17 @@ The client expects either the following environment parameters to be set, or to 
   MTLS_ROOT_CA_NAME // The name of an SSM parameter holding the root ca
 
 ```
+
+Example use:
+```
 // create a client
 const apiClient = new ApiClient();
 // init (get parameters from store etc.)
 await apiClient.init();
-// Use the client to request data
-const data = await apiClient.requestData('/test', { data: 'test ' },  {'Content-type': 'application/json'});
+// Use the client to perform a POST request and get responses.
+const data = await apiClient.postData('/test', { data: 'test ' },  {'Content-type': 'application/json'});
+
+// Use the client to perform a GET request and get data.
+const data = await apiClient.getData('/test',  {'Content-type': 'application/json'});
 ```
 The request can throw an error, the actual message is logged, a generic Error is thrown.

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -95,8 +95,7 @@ describe('Init', () => {
   });
 });
 
-
-describe('Requests', () => {
+describe('postData Requests', () => {
   test('Return data', async () => {
     //required env params:
     testSetup();
@@ -105,7 +104,7 @@ describe('Requests', () => {
 
     const apiClient = new ApiClient();
     await apiClient.init();
-    const data = await apiClient.requestData('/test', { data: 'test ' });
+    const data = await apiClient.postData('/test', { data: 'test ' });
     expect(data).toEqual(returnData);
   });
 
@@ -117,11 +116,11 @@ describe('Requests', () => {
     const apiClient = new ApiClient();
     await apiClient.init();
     return expect(async() => {
-      await apiClient.requestData('/test', { data: 'test ' });
+      await apiClient.postData('/test', { data: 'test ' });
     }).rejects.toThrow();
     let result: any;
     try {
-      await apiClient.requestData('/test', { data: 'test ' });
+      await apiClient.postData('/test', { data: 'test ' });
     } catch (error) {
       result = error;
     }
@@ -136,17 +135,122 @@ describe('Requests', () => {
     const apiClient = new ApiClient();
     await apiClient.init();
     return expect(async() => {
-      await apiClient.requestData('/test', { data: 'test ' });
+      await apiClient.postData('/test', { data: 'test ' });
     }).rejects.toThrow();
     let result: any;
     try {
-      await apiClient.requestData('/test', { data: 'test ' });
+      await apiClient.postData('/test', { data: 'test ' });
     } catch (error) {
       result = error;
     }
     expect(result.message).toBe('Het ophalen van gegevens is misgegaan.');
   });
 });
+
+describe('Deprecated requestData Requests', () => {
+  test('Return data', async () => {
+    //required env params:
+    testSetup();
+    const returnData = { users: [{ id: 1, name: 'John Smith' }] };
+    axiosMock.onPost('/test').reply(200, returnData);
+
+    const apiClient = new ApiClient();
+    await apiClient.init();
+    const data = await apiClient.postData('/test', { data: 'test ' });
+    expect(data).toEqual(returnData);
+  });
+
+  test('Timeout', async () => {
+    //required env params:
+    testSetup();
+    axiosMock.onPost('/test').timeout();
+
+    const apiClient = new ApiClient();
+    await apiClient.init();
+    return expect(async() => {
+      await apiClient.postData('/test', { data: 'test ' });
+    }).rejects.toThrow();
+    let result: any;
+    try {
+      await apiClient.postData('/test', { data: 'test ' });
+    } catch (error) {
+      result = error;
+    }
+    expect(result.message).toBe('Het ophalen van gegevens is misgegaan.');
+  });
+
+  test('Network error', async () => {
+    //required env params:
+    testSetup();
+    axiosMock.onPost('/test').networkError();
+
+    const apiClient = new ApiClient();
+    await apiClient.init();
+    return expect(async() => {
+      await apiClient.postData('/test', { data: 'test ' });
+    }).rejects.toThrow();
+    let result: any;
+    try {
+      await apiClient.postData('/test', { data: 'test ' });
+    } catch (error) {
+      result = error;
+    }
+    expect(result.message).toBe('Het ophalen van gegevens is misgegaan.');
+  });
+});
+
+describe('GET Requests', () => {
+  test('Return data', async () => {
+    //required env params:
+    testSetup();
+    const returnData = { users: [{ id: 1, name: 'John Smith' }] };
+    axiosMock.onGet('/test').reply(200, returnData);
+
+    const apiClient = new ApiClient();
+    await apiClient.init();
+    const data = await apiClient.getData('/test');
+    expect(data).toEqual(returnData);
+  });
+
+  test('Timeout', async () => {
+    //required env params:
+    testSetup();
+    axiosMock.onGet('/test').timeout();
+
+    const apiClient = new ApiClient();
+    await apiClient.init();
+    return expect(async() => {
+      await apiClient.getData('/test');
+    }).rejects.toThrow();
+    let result: any;
+    try {
+      await apiClient.getData('/test', { data: 'test ' });
+    } catch (error) {
+      result = error;
+    }
+    expect(result.message).toBe('Het ophalen van gegevens is misgegaan.');
+  });
+
+  test('Network error', async () => {
+    //required env params:
+    testSetup();
+    axiosMock.onGet('/test').networkError();
+
+    const apiClient = new ApiClient();
+    await apiClient.init();
+    return expect(async() => {
+      await apiClient.getData('/test', { data: 'test ' });
+    }).rejects.toThrow();
+    let result: any;
+    try {
+      await apiClient.getData('/test', { data: 'test ' });
+    } catch (error) {
+      result = error;
+    }
+    expect(result.message).toBe('Het ophalen van gegevens is misgegaan.');
+  });
+});
+
 
 
 function testSetup() {


### PR DESCRIPTION
The client could only perform POST requests. This PR adds support for GET requests. The method used is made explicit in the api, the `requestData` method is deprecated. `postData` is a drop-in replacement for this function, and has the same method signature. The `requestData` method will be removed in the next major release.

To perform a GET, use the `getData` method. It is used the same way the POST method is, but has no `body` parameter.