### PR TITLE
fix: Await https agent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,7 @@ export class ApiClient {
   }
 
   async getData(endpoint: string, headers?: any): Promise<any> {
-    const httpsAgent = this.setupAgent();
+    const httpsAgent = await this.setupAgent();
     console.time('GET request to ' + endpoint);
     try {
       const response = await axios.get(endpoint, {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -115,7 +115,7 @@ describe('postData Requests', () => {
 
     const apiClient = new ApiClient();
     await apiClient.init();
-    return expect(async() => {
+    await expect(async() => {
       await apiClient.postData('/test', { data: 'test ' });
     }).rejects.toThrow();
     let result: any;
@@ -134,7 +134,7 @@ describe('postData Requests', () => {
 
     const apiClient = new ApiClient();
     await apiClient.init();
-    return expect(async() => {
+    await expect(async() => {
       await apiClient.postData('/test', { data: 'test ' });
     }).rejects.toThrow();
     let result: any;
@@ -167,7 +167,7 @@ describe('Deprecated requestData Requests', () => {
 
     const apiClient = new ApiClient();
     await apiClient.init();
-    return expect(async() => {
+    await expect(async() => {
       await apiClient.postData('/test', { data: 'test ' });
     }).rejects.toThrow();
     let result: any;
@@ -186,7 +186,7 @@ describe('Deprecated requestData Requests', () => {
 
     const apiClient = new ApiClient();
     await apiClient.init();
-    return expect(async() => {
+    await expect(async() => {
       await apiClient.postData('/test', { data: 'test ' });
     }).rejects.toThrow();
     let result: any;
@@ -219,7 +219,7 @@ describe('GET Requests', () => {
 
     const apiClient = new ApiClient();
     await apiClient.init();
-    return expect(async() => {
+    await expect(async() => {
       await apiClient.getData('/test');
     }).rejects.toThrow();
     let result: any;
@@ -238,7 +238,7 @@ describe('GET Requests', () => {
 
     const apiClient = new ApiClient();
     await apiClient.init();
-    return expect(async() => {
+    await expect(async() => {
       await apiClient.getData('/test', { data: 'test ' });
     }).rejects.toThrow();
     let result: any;


### PR DESCRIPTION
When performing get requests, the httpsAgent setup was not `await`ed correctly.