### PR TITLE
feat: throw specific error on timeout

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -146,15 +146,14 @@ export class ApiClient {
         // The request was made and the server responded with a status code
         // that falls out of the range of 2xx
         console.log('http status for ' + endpoint + ': ' + error.response.status);
-
+      } else if (error?.code === 'ECONNABORTED') {
+        // Check for a timeout
+        throw new Error('Het ophalen van gegevens duurt te lang.');
       } else if (error.request) {
         // The request was made but no response was received
         // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
         // http.ClientRequest in node.js
         console.error(error?.code);
-        if (error?.code === 'ECONNABORTED') {
-          throw new Error('Het ophalen van gegevens duurde te lang.');
-        }
       } else {
         // Something happened in setting up the request that triggered an Error
         console.error(error.message);

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,6 +152,9 @@ export class ApiClient {
         // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
         // http.ClientRequest in node.js
         console.error(error?.code);
+        if(error?.code === 'ECONNABORTED'){
+          throw new Error('Het ophalen van gegevens duurde te lang.');
+        }
       } else {
         // Something happened in setting up the request that triggered an Error
         console.error(error.message);

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ export class ApiClient {
         // `error.request` is an instance of XMLHttpRequest in the browser and an instance of
         // http.ClientRequest in node.js
         console.error(error?.code);
-        if(error?.code === 'ECONNABORTED'){
+        if (error?.code === 'ECONNABORTED') {
           throw new Error('Het ophalen van gegevens duurde te lang.');
         }
       } else {

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -107,7 +107,7 @@ describe('postData Requests', () => {
     } catch (error) {
       result = error;
     }
-    expect(result.message).toBe('Het ophalen van gegevens is misgegaan.');
+    expect(result.message).toBe('Het ophalen van gegevens duurt te lang.');
   });
 
   test('Network error', async () => {
@@ -154,7 +154,7 @@ describe('Deprecated requestData Requests', () => {
     } catch (error) {
       result = error;
     }
-    expect(result.message).toBe('Het ophalen van gegevens is misgegaan.');
+    expect(result.message).toBe('Het ophalen van gegevens duurt te lang.');
   });
 
   test('Network error', async () => {
@@ -200,7 +200,7 @@ describe('GET Requests', () => {
     } catch (error) {
       result = error;
     }
-    expect(result.message).toBe('Het ophalen van gegevens is misgegaan.');
+    expect(result.message).toBe('Het ophalen van gegevens duurt te lang.');
   });
 
   test('Network error', async () => {


### PR DESCRIPTION
In de huidige interface is er geen manier om onderscheid te maken tussen een timeout of andere fouten.
Dat hebben we denk ik wel nodig omdat niet allen interne apis even snel zijn.